### PR TITLE
Make nginx PID 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM nginx:latest
+ADD entrypoint /
 COPY nginx.conf proxy.conf index.html styles.css /etc/nginx/rawgithack/
 RUN rm /etc/nginx/conf.d/default.conf && ln -sf /etc/nginx/rawgithack/nginx.conf /etc/nginx/conf.d/rawgithack.conf
 # put your SSL certificates here
 VOLUME /etc/ssl/private/rawgithack
 ENV DOMAIN githack.com
-CMD sed -i "s/githack.com/$DOMAIN/g" /etc/nginx/rawgithack/* && nginx -g "daemon off;"
+ENTRYPOINT ["/entrypoint"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/entrypoint
+++ b/entrypoint
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+sed -i "s/githack.com/$DOMAIN/g" /etc/nginx/rawgithack/*
+exec "$@"


### PR DESCRIPTION
Hi,

first of all, thank you for creating githack.com. It's great :+1:

While using your fork for our [preview website](https://github.com/elixirruhr/preview-website) I realized that nginx was not running as PID 1 so stopping a container regularly was not
possible:

    $ docker exec -it rawgithack ps x
      PID TTY      STAT   TIME COMMAND
        1 ?        Ss+    0:00 /bin/sh -c sed -i "s/githack.com/$DOMAIN/g" /etc/nginx/rawgithack/* && nginx -g "daemon off;"
        7 ?        S+     0:00 nginx: master process nginx -g daemon off;
       32 ?        Rs+    0:00 ps xo
    $ docker stop rawgithack
    # wait 10 seconds - docker then kills the container

After this commit nginx is PID 1 so stopping a container works
immediately:

    $ docker exec -it rawgithack ps x
      PID TTY      STAT   TIME COMMAND
        1 ?        Ss+    0:00 nginx: master process nginx -g daemon off;
       12 ?        Rs+    0:00 ps x
    $ docker stop rawgithack
    # stops immediately

Kind regards,
  Peter