### PR TITLE
Support files from Bitbucket snippets (closes #12)

### DIFF
--- a/rawgithack.js
+++ b/rawgithack.js
@@ -4,6 +4,15 @@
   var TEMPLATES = [
     [/^(https?):\/\/gitlab\.com\/([^\/]+\/[^\/]+)\/(?:raw|blob)\/(.+\..+?)(?:\?.*)?$/i, '$1://gl.githack.com/$2/raw/$3'],
     [/^(https?):\/\/bitbucket\.org\/([^\/]+\/[^\/]+)\/(?:raw|src)\/(.+\..+?)(?:\?.*)?$/i, '$1://bb.githack.com/$2/raw/$3'],
+
+    # snippet file URL from web interface, with revision
+    [/^(https?):\/\/bitbucket\.org\/snippets\/([^\/]+\/[^\/]+)\/revisions\/([^\/\#\?]+)(?:\?[^#]*)?(?:\#file-(.*))$/i, '$1://bb.githack.com/!api/2.0/snippets/$2/$3/files/$4'],
+    # snippet file URL from web interface, no revision
+    [/^(https?):\/\/bitbucket\.org\/snippets\/([^\/]+\/[^\/\#\?]+)(?:\?[^#]*)?(?:\#file-(.*))$/i, '$1://bb.githack.com/!api/2.0/snippets/$2/HEAD/files/$3'],
+    # snippet file URLs from REST API
+    [/^(https?):\/\/bitbucket\.org\/\!api\/2.0\/snippets\/([^\/]+\/[^\/]+\/[^\/]+)\/files\/(.+\..+?)(?:\?.*)?$/i, '$1://bb.githack.com/!api/2.0/snippets/$2/files/$3'],
+    [/^(https?):\/\/api\.bitbucket\.org\/2.0\/snippets\/([^\/]+\/[^\/]+\/[^\/]+)\/files\/(.+\..+?)(?:\?.*)?$/i, '$1://bb.githack.com/!api/2.0/snippets/$2/files/$3'],
+
     [/^(https?):\/\/raw\.github(?:usercontent)?\.com\/([^\/]+\/[^\/]+\/[^\/]+|[0-9A-Za-z-]+\/[0-9a-f]+\/raw)\/(.+\..+)/i, '$1://raw.githack.com/$2/$3'],
     [/^(https?):\/\/github\.com\/(.[^\/]+?)\/(.[^\/]+?)\/(?!releases\/)(?:(?:blob|raw)\/)?(.+?\/.+)/i, '$1://raw.githack.com/$2/$3/$4'],
     [/^(https?):\/\/gist\.github(?:usercontent)?\.com\/(.+?\/[0-9a-f]+\/raw\/(?:[0-9a-f]+\/)?.+\..+)$/i, '$1://gist.githack.com/$2']

--- a/rawgithack.js
+++ b/rawgithack.js
@@ -6,9 +6,9 @@
     [/^(https?):\/\/bitbucket\.org\/([^\/]+\/[^\/]+)\/(?:raw|src)\/(.+\..+?)(?:\?.*)?$/i, '$1://bb.githack.com/$2/raw/$3'],
 
     # snippet file URL from web interface, with revision
-    [/^(https?):\/\/bitbucket\.org\/snippets\/([^\/]+\/[^\/]+)\/revisions\/([^\/\#\?]+)(?:\?[^#]*)?(?:\#file-(.*))$/i, '$1://bb.githack.com/!api/2.0/snippets/$2/$3/files/$4'],
+    [/^(https?):\/\/bitbucket\.org\/snippets\/([^\/]+\/[^\/]+)\/revisions\/([^\/\#\?]+)(?:\?[^#]*)?(?:\#file-(.+\..+?))$/i, '$1://bb.githack.com/!api/2.0/snippets/$2/$3/files/$4'],
     # snippet file URL from web interface, no revision
-    [/^(https?):\/\/bitbucket\.org\/snippets\/([^\/]+\/[^\/\#\?]+)(?:\?[^#]*)?(?:\#file-(.*))$/i, '$1://bb.githack.com/!api/2.0/snippets/$2/HEAD/files/$3'],
+    [/^(https?):\/\/bitbucket\.org\/snippets\/([^\/]+\/[^\/\#\?]+)(?:\?[^#]*)?(?:\#file-(.+\..+?)$/i, '$1://bb.githack.com/!api/2.0/snippets/$2/HEAD/files/$3'],
     # snippet file URLs from REST API
     [/^(https?):\/\/bitbucket\.org\/\!api\/2.0\/snippets\/([^\/]+\/[^\/]+\/[^\/]+)\/files\/(.+\..+?)(?:\?.*)?$/i, '$1://bb.githack.com/!api/2.0/snippets/$2/files/$3'],
     [/^(https?):\/\/api\.bitbucket\.org\/2.0\/snippets\/([^\/]+\/[^\/]+\/[^\/]+)\/files\/(.+\..+?)(?:\?.*)?$/i, '$1://bb.githack.com/!api/2.0/snippets/$2/files/$3'],


### PR DESCRIPTION
This adds support for files from Bitbucket snippets in 4 different formats:

* 2 different REST API URL format (https//api.bitbucket.org/2.0/... and https://bitbucket.org/!api/2.0/...)
* Individual file URL from web app, without specific revision (this patch uses `HEAD` as the default)
* Individual file URL from web app, with a specific revision