### PR TITLE
Support .jscad extension for OpenJSCAD projects

### DIFF
--- a/rawgithack.conf
+++ b/rawgithack.conf
@@ -25,6 +25,7 @@ map $extension $detect_content_type {
     ~*^htc$                      text/x-component;
     ~*^html?$                  	 text/html;
     ~*^ics$		         text/calendar;
+    ~*^jscad$                    application/javascript;
     ~*^json$                     application/json;
     ~*^jsonld$                   application/ld+json;
     ~*^kml$               	 application/vnd.google-earth.kml+xml;


### PR DESCRIPTION
The [OpenJSCAD](openjscad.org) project uses the `.jscad` file extension
for its JavaScript 3D model files. Since the code is just JavaScript,
the extension should have the MIME type `application/javascript`.

Documentation: https://en.wikibooks.org/wiki/OpenJSCAD_User_Guide#Supported_Language_/_File_Formats