### PR TITLE
Support Range request for proxy

### DIFF
--- a/rawgithack.conf
+++ b/rawgithack.conf
@@ -124,6 +124,7 @@ server {
         proxy_cache_background_update on;
         proxy_cache_lock on;
 
+        proxy_force_ranges on;
         proxy_http_version 1.1;
         proxy_intercept_errors on;
         proxy_pass https://$origin;


### PR DESCRIPTION
Adding `proxy_force_ranges on;` seem to make nginx process partial requests. 

It doesn't create additional cache, but just makes nginx process range request regardless of whether origin server supports it. Cloudflare should also support this.

This option doesn't seem to be widely used. After searching, the one use case I found is here: 
https://gist.github.com/uupaa/ad00a1912b5770b0023d that also try to solve the problem of range request.

Gitlab request test:

```
curl -r 0-10 -v --header 'Host: glcdn.githack.com' 'http://localhost:8080/maomihz/wiki/raw/master/large.txt'

* Connected to localhost (::1) port 8080 (#0)
> GET /maomihz/wiki/raw/master/large.txt HTTP/1.1
> Host: glcdn.githack.com
> Range: bytes=0-10
> User-Agent: curl/7.47.0
> Accept: */*
> 
< HTTP/1.1 206 Partial Content
< Server: nginx/1.13.12
< Date: Thu, 19 Apr 2018 21:26:22 GMT
< Content-Length: 11
...
```

Bitbucket Test:

```
$ curl -r 0-1 -v --header 'Host: bbcdn.githack.com' 'http://localhost:8080/maomihz/wiki/raw/44f8ed6232b3917c99a1ebaccb6217e7bc4c7bc2/README.md' 

* Connected to localhost (::1) port 8080 (#0)
> GET /maomihz/wiki/raw/44f8ed6232b3917c99a1ebaccb6217e7bc4c7bc2/README.md HTTP/1.1
> Host: bbcdn.githack.com
> Range: bytes=0-1
> User-Agent: curl/7.47.0
> Accept: */*
> 
< HTTP/1.1 206 Partial Content
< Server: nginx/1.13.12
< Date: Thu, 19 Apr 2018 21:36:49 GMT
< Content-Length: 2
...
```


Relevant nginx manual: http://nginx.org/en/docs/http/ngx_http_proxy_module.html

Relevant issue: #24 