### PR TITLE
Use CloudFlare's much faster DNS resolvers

### DIFF
--- a/rawgithack.conf
+++ b/rawgithack.conf
@@ -114,7 +114,7 @@ server {
         }
 
         # to be able to resolve remote server name from a variable
-        resolver 8.8.8.8;
+        resolver 1.1.1.1 1.0.0.1;
 
         proxy_read_timeout 10s;
 


### PR DESCRIPTION
This PR changes the single Google Nameserver to both of CloudFlare's much faster DNS resolvers.