### PR TITLE
feat: support txt extension

### DIFF
--- a/rawgithack.conf
+++ b/rawgithack.conf
@@ -47,6 +47,7 @@ map $extension $detect_content_type {
     ~*^stl$               	 model/stl;
     ~*^tt(?:c|f)$                application/x-font-ttf;
     ~*^ttl$                      text/turtle;
+    ~*^txt$                      text/plain;
     ~*^vcard$            	 text/vcard;
     ~*^vcf$ 			 text/x-vcard;
     ~*^vtt$                      text/vtt;


### PR DESCRIPTION
[Production](https://rawcdn.githack.com/curbengh/urlhaus-filter/37bc5a5c3859eb9a32915417f20f85c98ce1896c/urlhaus-filter-online.txt) URL works, but not [development](https://raw.githack.com/curbengh/urlhaus-filter/master/urlhaus-filter-online.txt); it redirects to github.

GitLab [dev url](https://glcdn.githack.com/curben/urlhaus-filter/raw/master/urlhaus-filter.txt) is working.

Not sure if this PR fixes it, or perhaps the redirect is by design.