### PR TITLE
Adds support for RPM files

### DIFF
--- a/rawgithack.conf
+++ b/rawgithack.conf
@@ -58,12 +58,13 @@ map $extension $detect_content_type {
     ~*^xslt$                     application/xslt+xml;
     ~*^ya?ml$          	         text/yaml;
     ~*^wasm$                     application/wasm;
+    ~*^(?:d|s)?rpm$              application/x-redhat-package-manager;
     default               	 '';
 }
 
 # defines which extensions should include charset definition
 map $extension $content_type_charset_string {
-    ~*^(?:bat|eot|htc|kml|nt|otf|pdf|svg|swf|ttc|ttf|woff2?|wasm)$ '';
+    ~*^(?:bat|eot|htc|kml|nt|otf|pdf|svg|swf|ttc|ttf|woff2?|wasm|rpm|drpm|srpm)$ '';
     default '; charset=utf-8';
 }
 


### PR DESCRIPTION
github serves rpm files as `Content-Type: audio/pn-realaudio-plugin` and so does this site. 
also added options for delta (.drpm) and source (.srpm) rpm packages.