### PR TITLE
proper content-type for appinstaller

### DIFF
--- a/rawgithack.conf
+++ b/rawgithack.conf
@@ -17,6 +17,7 @@ error_log logs/error.log warn;
 # kind of workaround because nginx can detect mime-type only for local file
 map $extension $detect_content_type {
     ~*^(?:appcache|manifest)$    text/cache-manifest;
+    ~*^appinstaller$             application/appinstaller;
     ~*^atom$                     application/atom+xml;
     ~*^bat$               	 application/x-msdownload;
     ~*^coffee$                   text/coffeescript;


### PR DESCRIPTION
as described on https://docs.microsoft.com/en-us/windows/msix/app-installer/web-install-iis

appinstaller are xml files served as "text/plain" at the moment