### PR TITLE
Pass {git,hg}.sr.ht via srh{,g}t.githack.com

### DIFF
--- a/rawgithack.conf
+++ b/rawgithack.conf
@@ -78,6 +78,8 @@ map $host $origin {
     ~*^bb(cdn)?.githack.com$ bitbucket.org;
     ~*^raw(cdn)?.githack.com$ raw.githubusercontent.com;
     ~*^gist(cdn)?.githack.com$ gist.githubusercontent.com;
+    ~*^srht(cdn)?.githack.com$ git.sr.ht;
+    ~*^srhgt(cdn)?.githack.com$ hg.sr.ht;
 }
 
 map "$detect_content_type:$host" $check_redirect {

--- a/rawgithack.js
+++ b/rawgithack.js
@@ -38,7 +38,12 @@
     [/^(https?):\/\/github\.com\/(.[^\/]+?)\/(.[^\/]+?)\/(?!releases\/)(?:(?:blob|raw)\/)?(.+?\/.+)/i,
      '$1://raw.githack.com/$2/$3/$4'],
     [/^(https?):\/\/gist\.github(?:usercontent)?\.com\/(.+?\/[0-9a-f]+\/raw\/(?:[0-9a-f]+\/)?.+)$/i,
-     '$1://gist.githack.com/$2']
+     '$1://gist.githack.com/$2'],
+
+    [/^(https?):\/\/git\.sr\.ht\/(~[^\/]+\/[^\/]+\/blob\/.+\/.+)/i,
+     '$1://srht.githack.com/$2'],
+    [/^(https?):\/\/hg\.sr\.ht\/(~[^\/]+\/[^\/]+\/raw\/.+)/i,
+     '$1://srhgt.githack.com/$2']
   ];
 
   var prodEl = doc.getElementById('url-prod');


### PR DESCRIPTION
hg.sr.ht raw URLs are in the form https://srhgtcdn.githack.com/~sircmpwn/hg.sr.ht/raw/.hgtags?rev=tip, which needs the query parameter, but index.html says it won't be preserved, so not sure if that's viable.